### PR TITLE
Separate config logic form `main`

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+)
+
+type configuration struct {
+	watch_dir     string
+	bucket_name   string
+	bucket_prefix string
+	aws_region    string
+}
+
+// Load loads configuration values from environment variables and run validation checks.
+// It returns true if the configuration values are valid, false otherwise.
+func (c *configuration) Load() bool {
+	// Parse CLI flags
+	flag.Parse()
+
+	c.aws_region = *regionFlag
+
+	// Load configuration from CLI flags or environment variables
+	if *sourceFlag != "" {
+		c.watch_dir = *sourceFlag
+	} else {
+		c.watch_dir = os.Getenv("WATCH_DIR")
+	}
+
+	if *bucketFlag != "" {
+		c.bucket_name = *bucketFlag
+	} else {
+		c.bucket_name = os.Getenv("S3_BUCKET_NAME")
+	}
+
+	if *prefixFlag != "" {
+		c.bucket_prefix = *prefixFlag
+	} else {
+		c.bucket_prefix = os.Getenv("S3_BUCKET_PREFIX")
+	}
+
+	// Validate configuration values
+	return c.Validate()
+}
+
+// Validate encapsulates the validation logic for the configuration values.
+// It returns true if the configuration values are valid, false otherwise.
+func (c *configuration) Validate() bool {
+	// Validate source directory
+	if _, err := os.Stat(config.watch_dir); os.IsNotExist(err) {
+		log.Printf("Invalid source directory. Please provide a valid directory path. Example: /path/to/source")
+		return false
+	}
+
+	// Validate bucket name
+	if config.bucket_name == "" {
+		log.Printf("Invalid S3 bucket name. Please provide a valid bucket name. Example: my-s3-bucket")
+		return false
+	}
+
+	// Validate prefix
+	if config.bucket_prefix == "" {
+		log.Printf("Invalid S3 prefix. Please provide a valid prefix. Example: my-prefix/")
+		return false
+	}
+
+	return true
+}

--- a/config.go
+++ b/config.go
@@ -6,16 +6,20 @@ import (
 	"os"
 )
 
-type configuration struct {
+type Configuration struct {
 	watch_dir     string
 	bucket_name   string
 	bucket_prefix string
 	aws_region    string
 }
 
-// Load loads configuration values from environment variables and run validation checks.
-// It returns true if the configuration values are valid, false otherwise.
-func (c *configuration) Load() bool {
+// NewConfiguration creates a new empty Configuration object.
+func NewConfiguration() *Configuration {
+	return &Configuration{}
+}
+
+// Load loads configuration values from environment variables or CLI flags.
+func (c *Configuration) Load() {
 	// Parse CLI flags
 	flag.Parse()
 
@@ -39,31 +43,37 @@ func (c *configuration) Load() bool {
 	} else {
 		c.bucket_prefix = os.Getenv("S3_BUCKET_PREFIX")
 	}
-
-	// Validate configuration values
-	return c.Validate()
 }
 
 // Validate encapsulates the validation logic for the configuration values.
 // It returns true if the configuration values are valid, false otherwise.
-func (c *configuration) Validate() bool {
+func (c *Configuration) Validate() bool {
+	// Assume configuration is valid and check for invalid values
+	valid := true
+
 	// Validate source directory
-	if _, err := os.Stat(config.watch_dir); os.IsNotExist(err) {
+	if _, err := os.Stat(c.watch_dir); os.IsNotExist(err) {
 		log.Printf("Invalid source directory. Please provide a valid directory path. Example: /path/to/source")
-		return false
+		valid = false
 	}
 
 	// Validate bucket name
-	if config.bucket_name == "" {
+	if c.bucket_name == "" {
 		log.Printf("Invalid S3 bucket name. Please provide a valid bucket name. Example: my-s3-bucket")
-		return false
+		valid = false
 	}
 
 	// Validate prefix
-	if config.bucket_prefix == "" {
+	if c.bucket_prefix == "" {
 		log.Printf("Invalid S3 prefix. Please provide a valid prefix. Example: my-prefix/")
-		return false
+		valid = false
 	}
 
-	return true
+	// Validate AWS region
+	if c.aws_region == "" {
+		log.Printf("Invalid AWS region. Please provide a valid AWS region. Example: us-west-2")
+		valid = false
+	}
+
+	return valid
 }

--- a/config.go
+++ b/config.go
@@ -64,10 +64,7 @@ func (c *Configuration) Validate() bool {
 	}
 
 	// Validate prefix
-	if c.bucket_prefix == "" {
-		log.Printf("Invalid S3 prefix. Please provide a valid prefix. Example: my-prefix/")
-		valid = false
-	}
+	// An empty prefix is valid, so no need to validate it
 
 	// Validate AWS region
 	if c.aws_region == "" {

--- a/config.go
+++ b/config.go
@@ -43,6 +43,18 @@ func (c *Configuration) Load() {
 	} else {
 		c.bucket_prefix = os.Getenv("S3_BUCKET_PREFIX")
 	}
+
+	if *regionFlag != "" {
+		c.aws_region = *regionFlag
+	} else {
+		if os.Getenv("AWS_REGION") != "" {
+			c.aws_region = os.Getenv("AWS_REGION")
+		} else {
+			// When no region flag has been set try using the AWS_DEFAULT_REGION environment variable.
+			// This will be an emptry string if the environment variable is not set.
+			c.aws_region = os.Getenv("AWS_DEFAULT_REGION")
+		}
+	}
 }
 
 // Validate encapsulates the validation logic for the configuration values.

--- a/main.go
+++ b/main.go
@@ -68,68 +68,6 @@ func inizialize() {
 	log.SetOutput(os.Stdout)
 }
 
-type configuration struct {
-	watch_dir     string
-	bucket_name   string
-	bucket_prefix string
-	aws_region    string
-}
-
-// Load loads configuration values from environment variables and run validation checks.
-// It returns true if the configuration values are valid, false otherwise.
-func (c *configuration) Load() bool {
-	// Parse CLI flags
-	flag.Parse()
-
-	c.aws_region = *regionFlag
-
-	// Load configuration from CLI flags or environment variables
-	if *sourceFlag != "" {
-		c.watch_dir = *sourceFlag
-	} else {
-		c.watch_dir = os.Getenv("WATCH_DIR")
-	}
-
-	if *bucketFlag != "" {
-		c.bucket_name = *bucketFlag
-	} else {
-		c.bucket_name = os.Getenv("S3_BUCKET_NAME")
-	}
-
-	if *prefixFlag != "" {
-		c.bucket_prefix = *prefixFlag
-	} else {
-		c.bucket_prefix = os.Getenv("S3_BUCKET_PREFIX")
-	}
-
-	// Validate configuration values
-	return c.Validate()
-}
-
-// Validate encapsulates the validation logic for the configuration values.
-// It returns true if the configuration values are valid, false otherwise.
-func (c *configuration) Validate() bool {
-	// Validate source directory
-	if _, err := os.Stat(config.watch_dir); os.IsNotExist(err) {
-		log.Printf("Invalid source directory. Please provide a valid directory path. Example: /path/to/source")
-		return false
-	}
-
-	// Validate bucket name
-	if config.bucket_name == "" {
-		log.Printf("Invalid S3 bucket name. Please provide a valid bucket name. Example: my-s3-bucket")
-		return false
-	}
-
-	// Validate prefix
-	if config.bucket_prefix == "" {
-		log.Printf("Invalid S3 prefix. Please provide a valid prefix. Example: my-prefix/")
-		return false
-	}
-
-	return true
-}
-
 // startedFilteredWatcher starts a watcher on a directory and filters events based on the provided event list.
 func startedFilteredWatcher(dir string, ch chan fsnotify.Event, events ...fsnotify.Op) {
 	// Create a watcher

--- a/main.go
+++ b/main.go
@@ -24,15 +24,12 @@ var (
 	regionFlag = flag.String("region", "us-west-2", "The AWS region to use. Example: us-west-2")
 )
 
-type configuration struct {
-	watch_dir     string
-	bucket_name   string
-	bucket_prefix string
-	aws_region    string
-}
-
 func main() {
-	if !loadConfig() {
+	// Initialize the application
+	inizialize()
+
+	// Load configuration values
+	if success := config.Load(); !success {
 		log.Fatal("Failed to load configuration")
 	}
 	log.Print("Starting S3 File Watcher")
@@ -66,40 +63,52 @@ func main() {
 	wg.Wait()
 }
 
-// loadConfig loads configuration values from environment variables and run validation checks.
+func inizialize() {
+	// Log to stdout
+	log.SetOutput(os.Stdout)
+}
+
+type configuration struct {
+	watch_dir     string
+	bucket_name   string
+	bucket_prefix string
+	aws_region    string
+}
+
+// Load loads configuration values from environment variables and run validation checks.
 // It returns true if the configuration values are valid, false otherwise.
-func loadConfig() bool {
+func (c *configuration) Load() bool {
 	// Parse CLI flags
 	flag.Parse()
 
-	config.aws_region = *regionFlag
+	c.aws_region = *regionFlag
 
 	// Load configuration from CLI flags or environment variables
 	if *sourceFlag != "" {
-		config.watch_dir = *sourceFlag
+		c.watch_dir = *sourceFlag
 	} else {
-		config.watch_dir = os.Getenv("WATCH_DIR")
+		c.watch_dir = os.Getenv("WATCH_DIR")
 	}
 
 	if *bucketFlag != "" {
-		config.bucket_name = *bucketFlag
+		c.bucket_name = *bucketFlag
 	} else {
-		config.bucket_name = os.Getenv("S3_BUCKET_NAME")
+		c.bucket_name = os.Getenv("S3_BUCKET_NAME")
 	}
 
 	if *prefixFlag != "" {
-		config.bucket_prefix = *prefixFlag
+		c.bucket_prefix = *prefixFlag
 	} else {
-		config.bucket_prefix = os.Getenv("S3_BUCKET_PREFIX")
+		c.bucket_prefix = os.Getenv("S3_BUCKET_PREFIX")
 	}
 
 	// Validate configuration values
-	return validateConfig()
+	return c.Validate()
 }
 
-// validateConfig encapsulates the validation logic for the configuration values.
+// Validate encapsulates the validation logic for the configuration values.
 // It returns true if the configuration values are valid, false otherwise.
-func validateConfig() bool {
+func (c *configuration) Validate() bool {
 	// Validate source directory
 	if _, err := os.Stat(config.watch_dir); os.IsNotExist(err) {
 		log.Printf("Invalid source directory. Please provide a valid directory path. Example: /path/to/source")

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ var (
 	sourceFlag = flag.String("source", "", "The directory to upload to s3. Example: /path/to/source")
 	bucketFlag = flag.String("bucket", "", "The name of the bucket to upload the files to. Example: my-s3-bucket")
 	prefixFlag = flag.String("prefix", "", "The directory to upload to s3. Example: my-prefix/")
-	regionFlag = flag.String("region", "us-west-2", "The AWS region to use. Example: us-west-2")
+	regionFlag = flag.String("region", "", "The AWS region to use. Example: us-west-2")
 )
 
 func main() {


### PR DESCRIPTION
This pull request refactors the configuration loading and validation logic into a new `Configuration` struct and updates the corresponding tests. The most important changes include moving configuration logic to a new file, updating the main function to use the new configuration struct, and adding comprehensive tests for the new configuration logic.

**Configuration Refactor:**

* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R1-R88): Introduced a new `Configuration` struct with methods for loading and validating configuration values from environment variables and CLI flags.

**Main Function Update:**

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L19-R36): Removed the old configuration struct and related functions, replaced with the new `Configuration` struct. Updated the `main` function to use the new configuration loading and validation methods. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L19-R36) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L46-L48) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L60-R58) [[4]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L69-R69) [[5]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L158-R106) [[6]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L176-R124) [[7]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L208-R159)

**Testing Enhancements:**

* [`config_test.go`](diffhunk://#diff-4bb821dfaef1884915ee03c5488bded04807301bc3f41fc7001a078c330ae980R1-R164): Added comprehensive tests for the new `Configuration` struct, including tests for loading configuration from environment variables, CLI flags, and validation logic.

**Removed Redundant Code:**

* [`main_test.go`](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL1-L110): Removed old tests related to the previous configuration loading and validation logic.